### PR TITLE
Change dropdown-label and nav-link to be a lighter gray

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -199,7 +199,7 @@
       }
 
       .dropdown-label {
-        color: #4a4a4a;
+        color: #616060;
         cursor: pointer;
       }
 
@@ -239,7 +239,7 @@
       }
 
       .nav-link {
-        color: #4a4a4a;
+        color: #616060;
         margin-left: 3.5em;
         text-decoration: none;
       }


### PR DESCRIPTION
Before: #4a4a4a
![image](https://user-images.githubusercontent.com/44980366/130371068-bbde1ab5-a86d-4e0e-9e70-0c062a732954.png)

After: #616060
![image](https://user-images.githubusercontent.com/44980366/130371082-9c5bebfa-f463-4438-b711-d3f13e360336.png)
